### PR TITLE
Optional ngrok/tunneling instructions (to facilitate iOS dev testing)

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -30,6 +30,20 @@ config :littlechat, LittlechatWeb.Endpoint,
     ]
   ]
 
+config :ex_ngrok,
+  # The name of the Ngrok executable
+  executable: "ngrok",
+  # The type of tunnel (http, https, tcp, or tls)
+  protocol: "https",
+  # The port to which Ngrok will forward requests
+  port: "4000",
+  # The URL of Ngrok's API (used to retrieve its settings)
+  api_url: "http://localhost:4040/api/tunnels",
+  # The amount of sleep (in ms) to put between attempts to connect to Ngrok
+  sleep_between_attempts: 200,
+  # Any other tunneling options that will be passed directly to Ngrok
+  options: ""
+
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -30,19 +30,10 @@ config :littlechat, LittlechatWeb.Endpoint,
     ]
   ]
 
-config :ex_ngrok,
-  # The name of the Ngrok executable
-  executable: "ngrok",
-  # The type of tunnel (http, https, tcp, or tls)
-  protocol: "https",
-  # The port to which Ngrok will forward requests
-  port: "4000",
-  # The URL of Ngrok's API (used to retrieve its settings)
-  api_url: "http://localhost:4040/api/tunnels",
-  # The amount of sleep (in ms) to put between attempts to connect to Ngrok
-  sleep_between_attempts: 200,
-  # Any other tunneling options that will be passed directly to Ngrok
-  options: ""
+## ngrok config
+#
+# config :ex_ngrok,
+#   protocol: "https"
 
 # ## SSL Support
 #

--- a/mix.exs
+++ b/mix.exs
@@ -61,9 +61,11 @@ defmodule Littlechat.MixProject do
       {:stun, "~> 1.0"},
       {:sentry, "~> 8.0-rc.2"},
       {:hackney, "~> 1.8"}
-      # install ngrok https://github.com/joshuafleck/ex_ngrok#dependencies and
-      # uncomment the ex_ngrok dependency and do a mix deps.get to enable ex_ngrok
-      # and facilitate iOS device testing which requires https
+      # to facilitate iOS device testing in dev which requires https:
+      # install ngrok https://github.com/joshuafleck/ex_ngrok#dependencies
+      # uncomment the ex_ngrok dependency below and do a mix deps.get
+      # uncomment the ngrok config in dev.exs
+      #
       # access the unique ngrok URL displayed upon app start on your device:
       # ..
       # Generated littlechat app
@@ -72,6 +74,7 @@ defmodule Littlechat.MixProject do
       # (NB the URL changes upon each app start on free tier and is limited to 4 connections - https://ngrok.com/pricing
       # eg. use localhost on your dev computer)
       # can also be useful for testing between different and remote networks
+      # uncomment below:
       # {:ex_ngrok, "~> 0.3.0", only: [:dev]}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -57,9 +57,22 @@ defmodule Littlechat.MixProject do
       {:plug_cowboy, "~> 2.0"},
       {:uuid, "~> 1.1"},
       {:distillery, "~> 2.0"},
-      {:stun, "~> 1.0"}, # See https://github.com/processone/ejabberd/issues/1107#issuecomment-217828211 if you have errors installing this on macOS.
+      # See https://github.com/processone/ejabberd/issues/1107#issuecomment-217828211 if you have errors installing stun on macOS.
+      {:stun, "~> 1.0"},
       {:sentry, "~> 8.0-rc.2"},
       {:hackney, "~> 1.8"}
+      # install ngrok https://github.com/joshuafleck/ex_ngrok#dependencies and
+      # uncomment the ex_ngrok dependency and do a mix deps.get to enable ex_ngrok
+      # and facilitate iOS device testing which requires https
+      # access the unique ngrok URL displayed upon app start on your device:
+      # ..
+      # Generated littlechat app
+      # [info] ex_ngrok: Ngrok tunnel available at https://xyz.ngrok.io
+      # ..
+      # (NB the URL changes upon each app start on free tier and is limited to 4 connections - https://ngrok.com/pricing
+      # eg. use localhost on your dev computer)
+      # can also be useful for testing between different and remote networks
+      # {:ex_ngrok, "~> 0.3.0", only: [:dev]}
     ]
   end
 


### PR DESCRIPTION
webrtc on iOS requires https, which makes it difficult to test in dev
(tried self signed phx.gen.cert and installing the cert on iOS to no avail for the websockets wss - ymmv)

so ngrok (tunneling) to the rescue..

most likely instructions belongs in the readme or wiki, and not in the code - but here goes..